### PR TITLE
5.6 Deletion from planned & visited.

### DIFF
--- a/lib/domain/sight_repo.dart
+++ b/lib/domain/sight_repo.dart
@@ -6,16 +6,28 @@ final sightRepo = SightRepo();
 
 class SightRepo extends ChangeNotifier {
   final _mocks = generateMocks(10);
+  late final List<Sight> planned;
+  late final List<Sight> visited;
   final absentUrl =
       'https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/No_image_available.svg/480px-No_image_available.svg.png';
 
+  SightRepo() : super() {
+    planned = _mocks
+        .asMap()
+        .entries
+        .where((e) => e.key.isOdd)
+        .map((e) => e.value)
+        .toList();
+
+    visited = _mocks
+        .asMap()
+        .entries
+        .where((e) => e.key.isEven)
+        .map((e) => e.value)
+        .toList();
+  }
+
   Iterable<Sight> get all => _mocks;
-
-  Iterable<Sight> get planned =>
-      _mocks.asMap().entries.where((e) => e.key % 2 == 1).map((e) => e.value);
-
-  Iterable<Sight> get visited =>
-      _mocks.asMap().entries.where((e) => e.key % 2 == 0).map((e) => e.value);
 
   void saveSight(Sight sight) {
     _mocks.add(sight);

--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -27,7 +27,7 @@ class _AppState extends State<App> {
       title: 'Интересные места',
       theme: themeSwitcher.theme,
       home: col([
-        row([search, list]),
+        row([visiting]),
       ]),
     );
   }

--- a/lib/ui/screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen.dart
@@ -7,7 +7,12 @@ import 'package:places/ui/screen/widget/sight_card.dart';
 import 'package:places/ui/screen/widget/my_app_bar.dart';
 import 'package:places/ui/svg_icon.dart';
 
-class VisitingScreen extends StatelessWidget {
+class VisitingScreen extends StatefulWidget {
+  @override
+  _VisitingScreenState createState() => _VisitingScreenState();
+}
+
+class _VisitingScreenState extends State<VisitingScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -24,6 +29,7 @@ class VisitingScreen extends StatelessWidget {
             sights: sightRepo.planned,
             makeSightView: (sight) => SightCard(
               sight,
+              key: ObjectKey(sight),
               actions: [
                 IconButton(
                   icon: SvgIcon('res/figma/Icons/Icon/Calendar.svg'),
@@ -31,7 +37,8 @@ class VisitingScreen extends StatelessWidget {
                 ),
                 IconButton(
                   icon: SvgIcon('res/figma/Icons/Icon/Close.svg'),
-                  onPressed: () {},
+                  onPressed: () =>
+                      setState(() => sightRepo.planned.remove(sight)),
                 ),
               ],
               afterTitle: Column(
@@ -56,6 +63,7 @@ class VisitingScreen extends StatelessWidget {
             sights: sightRepo.visited,
             makeSightView: (sight) => SightCard(
               sight,
+              key: ObjectKey(sight),
               actions: [
                 IconButton(
                   icon: SvgIcon('res/figma/Icons/Icon/Share.svg'),
@@ -63,7 +71,8 @@ class VisitingScreen extends StatelessWidget {
                 ),
                 IconButton(
                   icon: SvgIcon('res/figma/Icons/Icon/Close.svg'),
-                  onPressed: () {},
+                  onPressed: () =>
+                      setState(() => sightRepo.visited.remove(sight)),
                 ),
               ],
               afterTitle: Column(

--- a/lib/ui/screen/widget/sight_card.dart
+++ b/lib/ui/screen/widget/sight_card.dart
@@ -11,9 +11,10 @@ class SightCard extends StatefulWidget {
 
   SightCard(
     this.sight, {
+    Key? key,
     required this.actions,
     required this.afterTitle,
-  });
+  }) : super(key: key);
 
   @override
   _SightCardState createState() => _SightCardState();


### PR DESCRIPTION
> Какой механизм вам для этого понадобился?

Понадобились ключи. Т.к. без них при удалении объекта из списка, flutter переиспользует RenderObjectы из старого списка не на своём месте.

> Как именно он отработал?

С ключами flutter понимает какой RenderObject с каким Widget'ом карточки связан. И переиспользует их в правильном порядке.
 
![image](https://user-images.githubusercontent.com/6170214/114086258-15fadb00-98bb-11eb-9286-5aa2cb773383.png)

Удаляю вторую карточку...

![image](https://user-images.githubusercontent.com/6170214/114086379-36c33080-98bb-11eb-9926-d2c230f7e8d7.png)
